### PR TITLE
feat: add nip5 endpoint

### DIFF
--- a/src/dice.rs
+++ b/src/dice.rs
@@ -128,7 +128,8 @@ impl RoundManager {
                             "{roller} was aiming for <{threshold}, and they got {roll}"
                         );
 
-                        // the send_private_message function (NIP17) seems to be not supported by major nostr clients.
+                        // the send_private_message function (NIP17) seems to be not supported by
+                        // major nostr clients.
                         #[allow(deprecated)]
                         if let Err(e) = self.client.send_direct_msg(roller, format!("You lost. You rolled {roll}, which was bigger than {threshold}. Try again!"), None).await {
                             tracing::error!(%roller, "Failed to send private message. Error: {e:#}");
@@ -137,7 +138,8 @@ impl RoundManager {
                         continue;
                     }
 
-                    // the send_private_message function (NIP17) seems to be not supported by major nostr clients.
+                    // the send_private_message function (NIP17) seems to be not supported by major
+                    // nostr clients.
                     #[allow(deprecated)]
                     if let Err(e) = self
                         .client

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,9 @@ mod routes;
 mod subscriber;
 mod zapper;
 
+pub const MAIN_KEY_NAME: &str = "roll";
+pub const NONCE_KEY_NAME: &str = "nonce";
+
 #[derive(Clone)]
 pub struct State {
     pub db: Db,

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -2,6 +2,8 @@ use crate::db;
 use crate::db::upsert_zap;
 use crate::db::Zap;
 use crate::State;
+use crate::MAIN_KEY_NAME;
+use crate::NONCE_KEY_NAME;
 use anyhow::anyhow;
 use anyhow::bail;
 use anyhow::Context;
@@ -240,8 +242,14 @@ pub async fn get_nip05(
 ) -> Result<Json<Nip05Response>, (StatusCode, Json<Value>)> {
     let all = Nip05Response {
         names: HashMap::from([
-            ("roll".to_string(), state.main_keys.public_key().to_hex()),
-            ("nonce".to_string(), state.nonce_keys.public_key().to_hex()),
+            (
+                MAIN_KEY_NAME.to_string(),
+                state.main_keys.public_key().to_hex(),
+            ),
+            (
+                NONCE_KEY_NAME.to_string(),
+                state.nonce_keys.public_key().to_hex(),
+            ),
         ]),
         relays: HashMap::from([
             (state.main_keys.public_key().to_hex(), state.relays.clone()),
@@ -250,16 +258,19 @@ pub async fn get_nip05(
     };
     if let Some(name) = &params.name {
         return match name.as_str() {
-            "roll" => Ok(Json(Nip05Response {
-                names: HashMap::from([("roll".to_string(), state.main_keys.public_key().to_hex())]),
+            MAIN_KEY_NAME => Ok(Json(Nip05Response {
+                names: HashMap::from([(
+                    MAIN_KEY_NAME.to_string(),
+                    state.main_keys.public_key().to_hex(),
+                )]),
                 relays: HashMap::from([(
                     state.main_keys.public_key().to_hex(),
                     state.relays.clone(),
                 )]),
             })),
-            "nonce" => Ok(Json(Nip05Response {
+            NONCE_KEY_NAME => Ok(Json(Nip05Response {
                 names: HashMap::from([(
-                    "nonce".to_string(),
+                    NONCE_KEY_NAME.to_string(),
                     state.nonce_keys.public_key().to_hex(),
                 )]),
                 relays: HashMap::from([(


### PR DESCRIPTION
A query param as defined in nip05 can be added to filter the response or all known nip05 identities are returned

Test with: 

http://localhost/.well-known/nostr.json?name=roll

```json
{
  "names": {
    "roll": "8be6e9d57431eefbe9a53c7e9828d5a8a6c0645cc5bfc1c84e5cfd863f1e8e0d"
  },
  "relays": {
    "8be6e9d57431eefbe9a53c7e9828d5a8a6c0645cc5bfc1c84e5cfd863f1e8e0d": [
      "ws://nostr-rs-relay:8080"
    ]
  }
}
```