### PR TITLE
Ensure that zap invoice commits to bet terms

### DIFF
--- a/src/nonce.rs
+++ b/src/nonce.rs
@@ -194,7 +194,7 @@ impl Nonce {
     }
 }
 
-fn nonce_commitment(nonce: [u8; 32]) -> sha256::Hash {
+pub fn nonce_commitment(nonce: [u8; 32]) -> sha256::Hash {
     let mut hasher = sha256::Hash::engine();
     hasher.input(&nonce);
 

--- a/src/payouts.rs
+++ b/src/payouts.rs
@@ -1,21 +1,3 @@
-// - no instant payout
-//
-// - publish multiplier notes once
-// - announce commitment and nonce reveal on different account
-//
-// roll = first_2_bytes_in_decimal(sha256(nonce | npub | memo))
-//
-// ## zap invoice
-//
-// User claims they are owed zap_amount * multiplier
-//
-// - amount
-// - description/m: nonce commitment noteId, nonce commitment, multiplier note id, roller's npub,
-//   memo
-// - signature proves that we approved this zap request
-//
-// ## payout invoice
-
 use crate::db;
 use crate::db::upsert_zap;
 use crate::db::BetState;


### PR DESCRIPTION
A roller claiming fraud will have to show their zap invoice, together with the corresponding preimage. The invoice signed by NostrDice proves that NostrDice agreed to the bet. Knowledge of the preimage proves that the roller agreed to the bet and paid for it.